### PR TITLE
Keybindings features

### DIFF
--- a/Terminal.Gui/Core/Command.cs
+++ b/Terminal.Gui/Core/Command.cs
@@ -110,5 +110,10 @@ namespace Terminal.Gui {
 		/// Toggle the checked state.
 		/// </summary>
 		ToggleChecked,
+
+		/// <summary>
+		/// Executes an accept key event.
+		/// </summary>
+		AcceptKey,
 	}
 }

--- a/Terminal.Gui/Core/Command.cs
+++ b/Terminal.Gui/Core/Command.cs
@@ -112,6 +112,16 @@ namespace Terminal.Gui {
 		ToggleChecked,
 
 		/// <summary>
+		/// Executes a hot key event.
+		/// </summary>
+		ExecuteHotKey,
+
+		/// <summary>
+		/// Executes a cold key event.
+		/// </summary>
+		ExecuteColdKey,
+
+		/// <summary>
 		/// Executes an accept key event.
 		/// </summary>
 		AcceptKey,

--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -124,6 +124,11 @@ namespace Terminal.Gui {
 		Size size;
 
 		/// <summary>
+		/// Event invoked when the <see cref="HotKey"/> is changed.
+		/// </summary>
+		public event Action<Key> HotKeyChanged;
+
+		/// <summary>
 		///   The text to be displayed. This text is never modified.
 		/// </summary>
 		public virtual ustring Text {
@@ -270,7 +275,16 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Gets the hotkey. Will be an upper case letter or digit.
 		/// </summary>
-		public Key HotKey { get => hotKey; internal set => hotKey = value; }
+		public Key HotKey {
+			get => hotKey;
+			internal set {
+				if (hotKey != value) {
+					var oldKey = hotKey;
+					hotKey = value;
+					HotKeyChanged?.Invoke (oldKey);
+				}
+			}
+		}
 
 		/// <summary>
 		/// Specifies the mask to apply to the hotkey to tag it as the hotkey. The default value of <c>0x100000</c> causes
@@ -304,7 +318,8 @@ namespace Terminal.Gui {
 
 				if (NeedsFormat) {
 					var shown_text = text;
-					if (FindHotKey (text, HotKeySpecifier, true, out hotKeyPos, out hotKey)) {
+					if (FindHotKey (text, HotKeySpecifier, true, out hotKeyPos, out Key newHotKey)) {
+						HotKey = newHotKey;
 						shown_text = RemoveHotKeySpecifier (Text, hotKeyPos, HotKeySpecifier);
 						shown_text = ReplaceHotKeyWithTag (shown_text, hotKeyPos);
 					}

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -259,7 +259,7 @@ namespace Terminal.Gui {
 		/// Configurable keybindings supported by the control
 		/// </summary>
 		private Dictionary<Key, Command> KeyBindings { get; set; } = new Dictionary<Key, Command> ();
-		private Dictionary<Command, Action> CommandImplementations { get; set; } = new Dictionary<Command, Action> ();
+		private Dictionary<Command, Func<KeyEvent, bool>> CommandImplementations { get; set; } = new Dictionary<Command, Func<KeyEvent, bool>> ();
 
 		/// <summary>
 		/// This returns a tab index list of the subviews contained by this view.
@@ -1576,8 +1576,7 @@ namespace Terminal.Gui {
 					throw new NotSupportedException ($"A KeyBinding was set up for the command {command} ({keyEvent.Key}) but that command is not supported by this View ({GetType ().Name})");
 				}
 
-				CommandImplementations [command] ();
-				return true;
+				return CommandImplementations [command] (keyEvent);
 			}
 
 			return false;
@@ -1637,22 +1636,22 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// <para>States that the given <see cref="View"/> supports a given <paramref name="command"/>
-		/// and what <paramref name="action"/> to perform to make that command happen
+		/// and what <paramref name="f"/> to perform to make that command happen
 		/// </para>
-		/// <para>If the <paramref name="command"/> already has an implementation the <paramref name="action"/>
+		/// <para>If the <paramref name="command"/> already has an implementation the <paramref name="f"/>
 		/// will replace the old one</para>
 		/// </summary>
-		/// <param name="command"></param>
-		/// <param name="action"></param>
-		protected void AddCommand (Command command, Action action)
+		/// <param name="command">The command.</param>
+		/// <param name="f">The function.</param>
+		protected void AddCommand (Command command, Func<KeyEvent, bool> f)
 		{
 			// if there is already an implementation of this command
 			if (CommandImplementations.ContainsKey (command)) {
 				// replace that implementation
-				CommandImplementations [command] = action;
+				CommandImplementations [command] = f;
 			} else {
 				// else record how to perform the action (this should be the normal case)
-				CommandImplementations.Add (command, action);
+				CommandImplementations.Add (command, f);
 			}
 		}
 

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -259,7 +259,7 @@ namespace Terminal.Gui {
 		/// Configurable keybindings supported by the control
 		/// </summary>
 		private Dictionary<Key, Command> KeyBindings { get; set; } = new Dictionary<Key, Command> ();
-		private Dictionary<Command, Func<KeyEvent, bool>> CommandImplementations { get; set; } = new Dictionary<Command, Func<KeyEvent, bool>> ();
+		private Dictionary<Command, Func<object [], bool>> CommandImplementations { get; set; } = new Dictionary<Command, Func<object [], bool>> ();
 
 		/// <summary>
 		/// This returns a tab index list of the subviews contained by this view.
@@ -1566,8 +1566,9 @@ namespace Terminal.Gui {
 		/// Invokes any binding that is registered on this <see cref="View"/>
 		/// and matches the <paramref name="keyEvent"/>
 		/// </summary>
-		/// <param name="keyEvent"></param>
-		protected bool InvokeKeybindings (KeyEvent keyEvent)
+		/// <param name="keyEvent">The key event passed.</param>
+		/// <param name="args">The arguments to send to the command.</param>
+		protected bool InvokeKeybindings (KeyEvent keyEvent, params object [] args)
 		{
 			if (KeyBindings.ContainsKey (keyEvent.Key)) {
 				var command = KeyBindings [keyEvent.Key];
@@ -1576,7 +1577,7 @@ namespace Terminal.Gui {
 					throw new NotSupportedException ($"A KeyBinding was set up for the command {command} ({keyEvent.Key}) but that command is not supported by this View ({GetType ().Name})");
 				}
 
-				return CommandImplementations [command] (keyEvent);
+				return CommandImplementations [command] (args);
 			}
 
 			return false;
@@ -1643,7 +1644,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <param name="command">The command.</param>
 		/// <param name="f">The function.</param>
-		protected void AddCommand (Command command, Func<KeyEvent, bool> f)
+		protected void AddCommand (Command command, Func<object [], bool> f)
 		{
 			// if there is already an implementation of this command
 			if (CommandImplementations.ContainsKey (command)) {

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -57,7 +57,7 @@ namespace Terminal.Gui {
 		/// </param>
 		public Button (ustring text, bool is_default = false) : base (text)
 		{
-			Init (text, is_default);
+			Initialize (text, is_default);
 		}
 
 		/// <summary>
@@ -89,7 +89,7 @@ namespace Terminal.Gui {
 		public Button (int x, int y, ustring text, bool is_default)
 		    : base (new Rect (x, y, text.RuneCount + 4 + (is_default ? 2 : 0), 1), text)
 		{
-			Init (text, is_default);
+			Initialize (text, is_default);
 		}
 
 		Rune _leftBracket;
@@ -97,7 +97,7 @@ namespace Terminal.Gui {
 		Rune _leftDefault;
 		Rune _rightDefault;
 
-		void Init (ustring text, bool is_default)
+		void Initialize (ustring text, bool is_default)
 		{
 			TextAlignment = TextAlignment.Centered;
 
@@ -112,6 +112,33 @@ namespace Terminal.Gui {
 			this.is_default = is_default;
 			this.text = text ?? string.Empty;
 			Update ();
+
+			HotKeyChanged += Button_HotKeyChanged;
+
+			// Things this view knows how to do
+			AddCommand (Command.AcceptKey, () => AcceptKey ());
+
+			// Default keybindings for this view
+			AddKeyBinding (Key.AltMask | HotKey, Command.AcceptKey);
+			AddKeyBinding ((Key)'\n', Command.AcceptKey);
+
+			AddKeyBinding (Key.Enter, Command.AcceptKey);
+			AddKeyBinding (Key.Space, Command.AcceptKey);
+			if (HotKey != Key.Null) {
+				AddKeyBinding (Key.Space | HotKey, Command.AcceptKey);
+			}
+		}
+
+		private void Button_HotKeyChanged (Key obj)
+		{
+			ReplaceKeyBinding (Key.AltMask | obj, Key.AltMask | HotKey);
+			if (HotKey != Key.Null) {
+				if (ContainsKeyBinding (obj)) {
+					ReplaceKeyBinding (Key.Space | obj, Key.Space | HotKey);
+				} else {
+					AddKeyBinding (Key.Space | HotKey, Command.AcceptKey);
+				}
+			}
 		}
 
 		/// <summary>
@@ -171,16 +198,6 @@ namespace Terminal.Gui {
 			SetNeedsDisplay ();
 		}
 
-		bool CheckKey (KeyEvent key)
-		{
-			if (key.Key == (Key.AltMask | HotKey)) {
-				SetFocus ();
-				Clicked?.Invoke ();
-				return true;
-			}
-			return false;
-		}
-
 		///<inheritdoc/>
 		public override bool ProcessHotKey (KeyEvent kb)
 		{
@@ -188,8 +205,8 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			if (kb.IsAlt)
-				return CheckKey (kb);
+			if (kb.IsAlt && InvokeKeybindings (kb))
+				return true;
 
 			return false;
 		}
@@ -201,11 +218,10 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			if (IsDefault && kb.KeyValue == '\n') {
-				Clicked?.Invoke ();
+			if (IsDefault && InvokeKeybindings (kb))
 				return true;
-			}
-			return CheckKey (kb);
+
+			return false;
 		}
 
 		///<inheritdoc/>
@@ -215,14 +231,19 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			var c = kb.KeyValue;
-			if (c == '\n' || c == ' ' || kb.Key == HotKey) {
-				Clicked?.Invoke ();
+			if (InvokeKeybindings (kb))
 				return true;
-			}
+
 			return base.ProcessKey (kb);
 		}
 
+		void AcceptKey ()
+		{
+			if (!HasFocus) {
+				SetFocus ();
+			}
+			Clicked?.Invoke ();
+		}
 
 		/// <summary>
 		///   Clicked <see cref="Action"/>, raised when the user clicks the primary mouse button within the Bounds of this <see cref="View"/>

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -116,7 +116,7 @@ namespace Terminal.Gui {
 			HotKeyChanged += Button_HotKeyChanged;
 
 			// Things this view knows how to do
-			AddCommand (Command.ExecuteHotKey, (e) => ExecuteHotKey (e));
+			AddCommand (Command.ExecuteHotKey, (e) => ExecuteHotKey (e [0] as KeyEvent));
 			AddCommand (Command.ExecuteColdKey, (_) => ExecuteColdKey ());
 			AddCommand (Command.AcceptKey, (_) => AcceptKey ());
 
@@ -207,7 +207,7 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			if (InvokeKeybindings (kb))
+			if (InvokeKeybindings (kb, kb))
 				return true;
 
 			return false;

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -116,11 +116,13 @@ namespace Terminal.Gui {
 			HotKeyChanged += Button_HotKeyChanged;
 
 			// Things this view knows how to do
-			AddCommand (Command.AcceptKey, () => AcceptKey ());
+			AddCommand (Command.ExecuteHotKey, (e) => ExecuteHotKey (e));
+			AddCommand (Command.ExecuteColdKey, (_) => ExecuteColdKey ());
+			AddCommand (Command.AcceptKey, (_) => AcceptKey ());
 
 			// Default keybindings for this view
-			AddKeyBinding (Key.AltMask | HotKey, Command.AcceptKey);
-			AddKeyBinding ((Key)'\n', Command.AcceptKey);
+			AddKeyBinding (Key.AltMask | HotKey, Command.ExecuteHotKey);
+			AddKeyBinding ((Key)'\n', Command.ExecuteColdKey);
 
 			AddKeyBinding (Key.Enter, Command.AcceptKey);
 			AddKeyBinding (Key.Space, Command.AcceptKey);
@@ -205,7 +207,7 @@ namespace Terminal.Gui {
 				return false;
 			}
 
-			if (kb.IsAlt && InvokeKeybindings (kb))
+			if (InvokeKeybindings (kb))
 				return true;
 
 			return false;
@@ -214,11 +216,11 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override bool ProcessColdKey (KeyEvent kb)
 		{
-			if (!Enabled) {
+			if (!Enabled || !IsDefault) {
 				return false;
 			}
 
-			if (IsDefault && InvokeKeybindings (kb))
+			if (InvokeKeybindings (kb))
 				return true;
 
 			return false;
@@ -237,12 +239,29 @@ namespace Terminal.Gui {
 			return base.ProcessKey (kb);
 		}
 
-		void AcceptKey ()
+		bool ExecuteHotKey (KeyEvent ke)
+		{
+			if (ke.IsAlt) {
+				return AcceptKey ();
+			}
+			return false;
+		}
+
+		bool ExecuteColdKey ()
+		{
+			if (IsDefault) {
+				return AcceptKey ();
+			}
+			return false;
+		}
+
+		bool AcceptKey ()
 		{
 			if (!HasFocus) {
 				SetFocus ();
 			}
 			Clicked?.Invoke ();
+			return true;
 		}
 
 		/// <summary>

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -319,16 +319,16 @@ namespace Terminal.Gui {
 			CanFocus = true;
 
 			// Things this view knows how to do
-			AddCommand (Command.LineUp, () => MoveUp ());
-			AddCommand (Command.LineDown, () => MoveDown ());
-			AddCommand (Command.LineScrollUp, () => ScrollUp (1));
-			AddCommand (Command.LineScrollDown, () => ScrollDown (1));
-			AddCommand (Command.PageUp, () => MovePageUp ());
-			AddCommand (Command.PageDown, () => MovePageDown ());
-			AddCommand (Command.Home, () => MoveHome ());
-			AddCommand (Command.End, () => MoveEnd ());
-			AddCommand (Command.OpenSelectedItem, () => OnOpenSelectedItem ());
-			AddCommand (Command.ToggleChecked, () => MarkUnmarkRow ());
+			AddCommand (Command.LineUp, (_) => MoveUp ());
+			AddCommand (Command.LineDown, (_) => MoveDown ());
+			AddCommand (Command.LineScrollUp, (_) => ScrollUp (1));
+			AddCommand (Command.LineScrollDown, (_) => ScrollDown (1));
+			AddCommand (Command.PageUp, (_) => MovePageUp ());
+			AddCommand (Command.PageDown, (_) => MovePageDown ());
+			AddCommand (Command.Home, (_) => MoveHome ());
+			AddCommand (Command.End, (_) => MoveEnd ());
+			AddCommand (Command.OpenSelectedItem, (_) => OnOpenSelectedItem ());
+			AddCommand (Command.ToggleChecked, (_) => MarkUnmarkRow ());
 
 			// Default keybindings for all ListViews
 			AddKeyBinding (Key.CursorUp,Command.LineUp);
@@ -591,40 +591,44 @@ namespace Terminal.Gui {
 		/// Scrolls the view down.
 		/// </summary>
 		/// <param name="lines">Number of lines to scroll down.</param>
-		public virtual void ScrollDown (int lines)
+		public virtual bool ScrollDown (int lines)
 		{
 			top = Math.Max (Math.Min (top + lines, source.Count - 1), 0);
 			SetNeedsDisplay ();
+			return true;
 		}
 
 		/// <summary>
 		/// Scrolls the view up.
 		/// </summary>
 		/// <param name="lines">Number of lines to scroll up.</param>
-		public virtual void ScrollUp (int lines)
+		public virtual bool ScrollUp (int lines)
 		{
 			top = Math.Max (top - lines, 0);
 			SetNeedsDisplay ();
+			return true;
 		}
 
 		/// <summary>
 		/// Scrolls the view right.
 		/// </summary>
 		/// <param name="cols">Number of columns to scroll right.</param>
-		public virtual void ScrollRight (int cols)
+		public virtual bool ScrollRight (int cols)
 		{
 			left = Math.Max (Math.Min (left + cols, Maxlength - 1), 0);
 			SetNeedsDisplay ();
+			return true;
 		}
 
 		/// <summary>
 		/// Scrolls the view left.
 		/// </summary>
 		/// <param name="cols">Number of columns to scroll left.</param>
-		public virtual void ScrollLeft (int cols)
+		public virtual bool ScrollLeft (int cols)
 		{
 			left = Math.Max (left - cols, 0);
 			SetNeedsDisplay ();
+			return true;
 		}
 
 		int lastSelectedItem = -1;

--- a/UnitTests/ButtonTests.cs
+++ b/UnitTests/ButtonTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Terminal.Gui.Views {
+	public class ButtonTests {
+		[Fact]
+		public void Constructors_Defaults ()
+		{
+			var btn = new Button ();
+			Assert.Equal (string.Empty, btn.Text);
+			Assert.Equal ("[  ]", btn.GetType ().BaseType.GetProperty ("Text").GetValue (btn).ToString ());
+			Assert.False (btn.IsDefault);
+			Assert.Equal (TextAlignment.Centered, btn.TextAlignment);
+			Assert.Equal ('_', btn.HotKeySpecifier);
+			Assert.True (btn.CanFocus);
+			Assert.Equal (new Rect (0, 0, 4, 1), btn.Frame);
+			Assert.Equal (Key.Null, btn.HotKey);
+
+			btn = new Button ("Test", true);
+			Assert.Equal ("Test", btn.Text);
+			Assert.Equal ("[< Test >]", btn.GetType ().BaseType.GetProperty ("Text").GetValue (btn).ToString ());
+			Assert.True (btn.IsDefault);
+			Assert.Equal (TextAlignment.Centered, btn.TextAlignment);
+			Assert.Equal ('_', btn.HotKeySpecifier);
+			Assert.True (btn.CanFocus);
+			Assert.Equal (new Rect (0, 0, 10, 1), btn.Frame);
+			Assert.Equal (Key.Null, btn.HotKey);
+
+			btn = new Button (3, 4, "Test", true);
+			Assert.Equal ("Test", btn.Text);
+			Assert.Equal ("[< Test >]", btn.GetType ().BaseType.GetProperty ("Text").GetValue (btn).ToString ());
+			Assert.True (btn.IsDefault);
+			Assert.Equal (TextAlignment.Centered, btn.TextAlignment);
+			Assert.Equal ('_', btn.HotKeySpecifier);
+			Assert.True (btn.CanFocus);
+			Assert.Equal (new Rect (3, 4, 10, 1), btn.Frame);
+			Assert.Equal (Key.Null, btn.HotKey);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void KeyBindings_Command ()
+		{
+			var clicked = false;
+			Button btn = new Button ("Test");
+			btn.Clicked += () => clicked = true;
+			Application.Top.Add (btn);
+			Application.Begin (Application.Top);
+
+			Assert.Equal (Key.T, btn.HotKey);
+			Assert.False (btn.ProcessHotKey (new KeyEvent (Key.T, new KeyModifiers ())));
+			Assert.False (clicked);
+			Assert.True (btn.ProcessHotKey (new KeyEvent (Key.T | Key.AltMask, new KeyModifiers () { Alt = true })));
+			Assert.True (clicked);
+			clicked = false;
+			Assert.False (btn.IsDefault);
+			Assert.False (btn.ProcessColdKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.False (clicked);
+			btn.IsDefault = true;
+			Assert.True (btn.ProcessColdKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.True (clicked);
+			clicked = false;
+			Assert.True (btn.ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
+			Assert.True (clicked);
+			clicked = false;
+			Assert.True (btn.ProcessKey (new KeyEvent (Key.Space, new KeyModifiers ())));
+			Assert.True (clicked);
+			clicked = false;
+			Assert.True (btn.ProcessKey (new KeyEvent ((Key)'t', new KeyModifiers ())));
+			Assert.True (clicked);
+		}
+	}
+}

--- a/UnitTests/CheckboxTests.cs
+++ b/UnitTests/CheckboxTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Terminal.Gui.Views {
+	public class CheckboxTests {
+		[Fact]
+		public void Constructors_Defaults ()
+		{
+			var ckb = new CheckBox ();
+			Assert.False (ckb.Checked);
+			Assert.Equal (string.Empty, ckb.Text);
+			Assert.True (ckb.CanFocus);
+			Assert.Equal (new Rect (0, 0, 4, 1), ckb.Frame);
+
+			ckb = new CheckBox ("Test", true);
+			Assert.True (ckb.Checked);
+			Assert.Equal ("Test", ckb.Text);
+			Assert.True (ckb.CanFocus);
+			Assert.Equal (new Rect (0, 0, 8, 1), ckb.Frame);
+
+			ckb = new CheckBox (1, 2, "Test");
+			Assert.False (ckb.Checked);
+			Assert.Equal ("Test", ckb.Text);
+			Assert.True (ckb.CanFocus);
+			Assert.Equal (new Rect (1, 2, 8, 1), ckb.Frame);
+
+			ckb = new CheckBox (3, 4, "Test", true);
+			Assert.True (ckb.Checked);
+			Assert.Equal ("Test", ckb.Text);
+			Assert.True (ckb.CanFocus);
+			Assert.Equal (new Rect (3, 4, 8, 1), ckb.Frame);
+		}
+
+		[Fact]
+		[AutoInitShutdown]
+		public void KeyBindings_Command ()
+		{
+			var isChecked = false;
+			CheckBox ckb = new CheckBox ("Test");
+			ckb.Toggled += (e) => isChecked = true;
+			Application.Top.Add (ckb);
+			Application.Begin (Application.Top);
+
+			Assert.Equal (Key.Null, ckb.HotKey);
+			Assert.False (ckb.ProcessHotKey (new KeyEvent (Key.T, new KeyModifiers ())));
+			Assert.False (isChecked);
+			ckb.Text = "_Test";
+			Assert.Equal (Key.T, ckb.HotKey);
+			Assert.True (ckb.ProcessHotKey (new KeyEvent (Key.T | Key.AltMask, new KeyModifiers () { Alt = true })));
+			Assert.True (isChecked);
+			isChecked = false;
+			Assert.True (ckb.ProcessKey (new KeyEvent ((Key)' ', new KeyModifiers ())));
+			Assert.True (isChecked);
+			isChecked = false;
+			Assert.True (ckb.ProcessKey (new KeyEvent (Key.Space, new KeyModifiers ())));
+			Assert.True (isChecked);
+		}
+	}
+}

--- a/UnitTests/ListViewTests.cs
+++ b/UnitTests/ListViewTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -8,30 +9,79 @@ using Xunit;
 namespace Terminal.Gui.Views {
 	public class ListViewTests {
 		[Fact]
-		public void KeyBindings_Command () {
+		public void Constructors_Defaults ()
+		{
+			var lv = new ListView ();
+			Assert.Null (lv.Source);
+			Assert.True (lv.CanFocus);
+
+			lv = new ListView (new List<string> () { "One", "Two", "Three" });
+			Assert.NotNull (lv.Source);
+
+			lv = new ListView (new NewListDataSource());
+			Assert.NotNull (lv.Source);
+
+			lv = new ListView (new Rect (0, 1, 10, 20), new List<string> () { "One", "Two", "Three" });
+			Assert.NotNull (lv.Source);
+			Assert.Equal (new Rect (0, 1, 10, 20), lv.Frame);
+
+			lv = new ListView (new Rect (0, 1, 10, 20), new NewListDataSource ());
+			Assert.NotNull (lv.Source);
+			Assert.Equal (new Rect (0, 1, 10, 20), lv.Frame);
+		}
+
+		private class NewListDataSource : IListDataSource {
+			public int Count => throw new NotImplementedException ();
+
+			public int Length => throw new NotImplementedException ();
+
+			public bool IsMarked (int item)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public void Render (ListView container, ConsoleDriver driver, bool selected, int item, int col, int line, int width, int start = 0)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public void SetMark (int item, bool value)
+			{
+				throw new NotImplementedException ();
+			}
+
+			public IList ToList ()
+			{
+				throw new NotImplementedException ();
+			}
+		}
+
+		[Fact]
+		public void KeyBindings_Command ()
+		{
 			List<string> source = new List<string> () { "One", "Two", "Three" };
 			ListView lv = new ListView (source) { Height = 2, AllowsMarking = true };
 			Assert.Equal (0, lv.SelectedItem);
-			lv.ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.CursorDown, new KeyModifiers ())));
 			Assert.Equal (1, lv.SelectedItem);
-			lv.ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.CursorUp, new KeyModifiers ())));
 			Assert.Equal (0, lv.SelectedItem);
-			lv.ProcessKey (new KeyEvent (Key.PageDown, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.PageDown, new KeyModifiers ())));
 			Assert.Equal (2, lv.SelectedItem);
 			Assert.Equal (2, lv.TopItem);
-			lv.ProcessKey (new KeyEvent (Key.PageUp, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.PageUp, new KeyModifiers ())));
 			Assert.Equal (0, lv.SelectedItem);
 			Assert.Equal (0, lv.TopItem);
 			Assert.False (lv.Source.IsMarked (lv.SelectedItem));
-			lv.ProcessKey (new KeyEvent (Key.Space, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.Space, new KeyModifiers ())));
 			Assert.True (lv.Source.IsMarked (lv.SelectedItem));
 			var opened = false;
 			lv.OpenSelectedItem += (_) => opened = true;
-			lv.ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.Enter, new KeyModifiers ())));
 			Assert.True (opened);
-			lv.ProcessKey (new KeyEvent (Key.End, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.End, new KeyModifiers ())));
 			Assert.Equal (2, lv.SelectedItem);
-			lv.ProcessKey (new KeyEvent (Key.Home, new KeyModifiers ()));
+			Assert.True (lv.ProcessKey (new KeyEvent (Key.Home, new KeyModifiers ())));
 			Assert.Equal (0, lv.SelectedItem);
 		}
 	}


### PR DESCRIPTION
Unfortunately some of the key bindings need to compare some conditions that can not be through the current check. Ideally would be to call the functions with dynamic arguments that return a boolean value and not only always return true if an associated key exists. But an implementation of this gender is not very easy to develop.

**Edit:**
Replacing `Action` by `Func<KeyEvent, bool>` on `CommandImplementations` solves the gap from return depending on comparison.

**Edit2:**
Replaced to `Func<object [], bool>` on `CommandImplementations` to send any number of arguments to the command.
The `ExecuteColdKey` command on the `Button` view will never be call because already exist the same key on the `AcceptKey` command (`(Key)'\n'` and` Key.Enter` are equals). But that doesn't affect the functionality.