### PR TITLE
Fixed Frame != Bounds; changed UICat Scenarios list to use tableview!

### DIFF
--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -230,8 +230,9 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override void Redraw (Rect bounds)
 		{
+			base.Redraw (bounds);
+
 			Move (0, 0);
-			var frame = Frame;
 
 			scrollRightPoint = null;
 			scrollLeftPoint = null;
@@ -272,7 +273,7 @@ namespace Terminal.Gui {
 			int headerLinesConsumed = line;
 
 			//render the cells
-			for (; line < frame.Height; line++) {
+			for (; line < Bounds.Height; line++) {
 
 				ClearLine (line, bounds.Width);
 
@@ -1160,25 +1161,29 @@ namespace Terminal.Gui {
 				return true;
 			}
 
+			// TODO: Revert this (or not) once #2578 is solved
+			var boundsX = me.X - GetFramesThickness ().Left;
+			var boundsY = me.Y - GetFramesThickness ().Top;
+
 			if (me.Flags.HasFlag (MouseFlags.Button1Clicked)) {
 
 				if (scrollLeftPoint != null
-					&& scrollLeftPoint.Value.X == me.X
-					&& scrollLeftPoint.Value.Y == me.Y) {
+					&& scrollLeftPoint.Value.X == boundsX
+					&& scrollLeftPoint.Value.Y == boundsY) {
 					ColumnOffset--;
 					EnsureValidScrollOffsets ();
 					SetNeedsDisplay ();
 				}
 
 				if (scrollRightPoint != null
-					&& scrollRightPoint.Value.X == me.X
-					&& scrollRightPoint.Value.Y == me.Y) {
+					&& scrollRightPoint.Value.X == boundsX
+					&& scrollRightPoint.Value.Y == boundsY) {
 					ColumnOffset++;
 					EnsureValidScrollOffsets ();
 					SetNeedsDisplay ();
 				}
 
-				var hit = ScreenToCell (me.X, me.Y);
+				var hit = ScreenToCell (boundsX, boundsY);
 				if (hit != null) {
 
 					if (MultiSelect && HasControlOrAlt (me)) {
@@ -1193,7 +1198,7 @@ namespace Terminal.Gui {
 
 			// Double clicking a cell activates
 			if (me.Flags == MouseFlags.Button1DoubleClicked) {
-				var hit = ScreenToCell (me.X, me.Y);
+				var hit = ScreenToCell (boundsX, boundsY);
 				if (hit != null) {
 					OnCellActivated (new CellActivatedEventArgs (Table, hit.Value.X, hit.Value.Y));
 				}

--- a/UICatalog/UICatalog.cs
+++ b/UICatalog/UICatalog.cs
@@ -12,9 +12,10 @@ using System.Reflection;
 using System.Threading;
 using static Terminal.Gui.ConfigurationManager;
 using System.Text.Json.Serialization;
+using static Terminal.Gui.TableView;
+
 
 #nullable enable
-
 /// <summary>
 /// UI Catalog is a comprehensive sample library for Terminal.Gui. It provides a simple UI for adding to the catalog of scenarios.
 /// </summary>
@@ -253,8 +254,8 @@ namespace UICatalog {
 			public MenuItem? miIsMouseDisabled;
 			public MenuItem? miEnableConsoleScrolling;
 
-			public ListView CategoryListView;
-			public ListView ScenarioListView;
+			public ListView CategoryList;
+			public TableView ScenarioList;
 
 			public StatusItem Capslock;
 			public StatusItem Numlock;
@@ -323,7 +324,7 @@ namespace UICatalog {
 				//ContentPane.SetSplitterPos (0, 25);
 				//ContentPane.ShortcutAction = () => ContentPane.SetFocus ();
 
-				CategoryListView = new ListView (_categories) {
+				CategoryList = new ListView (_categories) {
 					X = 0,
 					Y = 1,
 					Width = Dim.Percent (30),
@@ -334,37 +335,40 @@ namespace UICatalog {
 					BorderStyle = LineStyle.Single,
 					SuperViewRendersLineCanvas = true
 				};
-				CategoryListView.OpenSelectedItem += (s, a) => {
-					ScenarioListView!.SetFocus ();
+				CategoryList.OpenSelectedItem += (s, a) => {
+					ScenarioList!.SetFocus ();
 				};
-				CategoryListView.SelectedItemChanged += CategoryListView_SelectedChanged;
+				CategoryList.SelectedItemChanged += CategoryView_SelectedChanged;
 
-				//ContentPane.Tiles.ElementAt (0).Title = "Categories";
-				//ContentPane.Tiles.ElementAt (0).MinSize = 2;
-				//ContentPane.Tiles.ElementAt (0).ContentView.Add (CategoryListView);
-
-				ScenarioListView = new ListView () {
-					X = Pos.Right (CategoryListView) - 1,
+				ScenarioList = new TableView () {
+					X = Pos.Right (CategoryList) - 1,
 					Y = 1,
 					Width = Dim.Fill (0),
 					Height = Dim.Fill (1),
-					AllowsMarking = false,
+					//AllowsMarking = false,
 					CanFocus = true,
 					Title = "Scenarios",
 					BorderStyle = LineStyle.Single,
 					SuperViewRendersLineCanvas = true
 				};
+				ScenarioList.FullRowSelect = true;
+				//ScenarioList.Style.ShowHeaders = false;
+				ScenarioList.Style.ShowHorizontalHeaderOverline = false;
+				//ScenarioList.Style.ShowHorizontalHeaderUnderline = false;
+				ScenarioList.Style.ShowHorizontalBottomline = false;
+				ScenarioList.Style.ShowVerticalCellLines = false;
+				ScenarioList.Style.ShowVerticalHeaderLines = false;
 
-				ScenarioListView.OpenSelectedItem += ScenarioListView_OpenSelectedItem;
+				var longestName = _scenarios!.Max (s => s.GetName ().Length);
+				ScenarioList.Style.ColumnStyles.Add (0, new ColumnStyle () { MaxWidth = longestName, MinWidth = longestName, MinAcceptableWidth = longestName });
+				ScenarioList.Style.ColumnStyles.Add (1, new ColumnStyle () {  MaxWidth = 1 });
 
-				//ContentPane.Tiles.ElementAt (1).Title = "Scenarios";
-				//ContentPane.Tiles.ElementAt (1).ContentView.Add (ScenarioListView);
-				//ContentPane.Tiles.ElementAt (1).MinSize = 2;
+				ScenarioList.CellActivated += ScenarioView_OpenSelectedItem;
 
 				KeyDown += KeyDownHandler;
-				//Add (ContentPane);
-				Add (CategoryListView);
-				Add (ScenarioListView);
+
+				Add (CategoryList);
+				Add (ScenarioList);
 
 				Add (MenuBar);
 				Add (StatusBar);
@@ -373,8 +377,10 @@ namespace UICatalog {
 				Unloaded += UnloadedHandler;
 
 				// Restore previous selections
-				CategoryListView.SelectedItem = _cachedCategoryIndex;
-				ScenarioListView.SelectedItem = _cachedScenarioIndex;
+				CategoryList.SelectedItem = _cachedCategoryIndex;
+				CategoryList.EnsureSelectedItemVisible ();
+				ScenarioList.SelectedRow = _cachedScenarioIndex;
+				ScenarioList.EnsureSelectedCellIsVisible ();
 
 				ConfigurationManager.Applied += ConfigAppliedHandler;
 			}
@@ -393,15 +399,15 @@ namespace UICatalog {
 					_isFirstRunning = false;
 				}
 				if (!_isFirstRunning) {
-					ScenarioListView.SetFocus ();
+					ScenarioList.SetFocus ();
 				}
 
 				StatusBar.VisibleChanged += (s, e) => {
 					UICatalogApp.ShowStatusBar = StatusBar.Visible;
 
 					var height = (StatusBar.Visible ? 1 : 0);
-					CategoryListView.Height = Dim.Fill (height);
-					ScenarioListView.Height = Dim.Fill (height);
+					CategoryList.Height = Dim.Fill (height);
+					ScenarioList.Height = Dim.Fill (height);
 					// ContentPane.Height = Dim.Fill (height);
 					LayoutSubviews ();
 					SetSubViewNeedsDisplay ();
@@ -425,16 +431,16 @@ namespace UICatalog {
 			/// Launches the selected scenario, setting the global _selectedScenario
 			/// </summary>
 			/// <param name="e"></param>
-			void ScenarioListView_OpenSelectedItem (object? sender, EventArgs? e)
+			void ScenarioView_OpenSelectedItem (object? sender, EventArgs? e)
 			{
 				if (_selectedScenario is null) {
 					// Save selected item state
-					_cachedCategoryIndex = CategoryListView.SelectedItem;
-					_cachedScenarioIndex = ScenarioListView.SelectedItem;
-					// Create new instance of scenario (even though Scenarios contains instances)
-					var sourceList = ScenarioListView.Source.ToList ();
+					_cachedCategoryIndex = CategoryList.SelectedItem;
+					_cachedScenarioIndex = ScenarioList.SelectedRow;
 
-					_selectedScenario = (Scenario)Activator.CreateInstance (ScenarioListView.Source.ToList () [ScenarioListView.SelectedItem]!.GetType ())!;
+					// Create new instance of scenario (even though Scenarios contains instances)
+					string selectedScenarioName = (string)ScenarioList.Table [ScenarioList.SelectedRow, 0];
+					_selectedScenario = (Scenario)Activator.CreateInstance (_scenarios!.FirstOrDefault (s => s.GetName () == selectedScenarioName)!.GetType ())!;
 
 					// Tell the main app to stop
 					Application.RequestStop ();
@@ -729,18 +735,22 @@ namespace UICatalog {
 				}
 			}
 
-			void CategoryListView_SelectedChanged (object? sender, ListViewItemEventArgs? e)
+			void CategoryView_SelectedChanged (object? sender, ListViewItemEventArgs? e)
 			{
 				var item = _categories! [e!.Item];
 				List<Scenario> newlist;
 				if (e.Item == 0) {
 					// First category is "All"
 					newlist = _scenarios!;
+					newlist = _scenarios!;
 
 				} else {
 					newlist = _scenarios!.Where (s => s.GetCategories ().Contains (item)).ToList ();
 				}
-				ScenarioListView.SetSource (newlist.ToList ());
+				ScenarioList.Table = new EnumerableTableSource<Scenario> (newlist, new Dictionary<string, Func<Scenario, object>> () {
+					{ "Name", (s) => s.GetName() },
+					{ "Description", (s) => s.GetDescription() },
+				});
 			}
 		}
 


### PR DESCRIPTION
Instead of a bunch of comments in code-review I decided to fix things by writing code.

- TV had some "Bounds != Frame" bugs latent since the move to the new View architecture. Fixed (with one TODO having to do with #2578)
- Updated UI Catalog to use TableView for the scenarios list instead of ListView. There's no reason to do this, really, other than an exercise in exercising TableView more ;-).

Things I learned:

- Getting column widths to work the way I want was confusing. I finally figured out I had to do all this, which is I don't fully undersatnd:

```cs
var longestName = _scenarios!.Max (s => s.GetName ().Length);
ScenarioList.Style.ColumnStyles.Add (0, new ColumnStyle () { MaxWidth = longestName, MinWidth = longestName, MinAcceptableWidth = longestName });
ScenarioList.Style.ColumnStyles.Add (1, new ColumnStyle () {  MaxWidth = 1 });
```

This gets me "1st Column is fixed at maximum width of scenario names and 2nd Column fills rest of view".  But the code certinly doesn't say that. What I expected to work:

```cs
var longestName = _scenarios!.Max (s => s.GetName ().Length);
ScenarioList.Style.ColumnStyles.Add (0, new ColumnStyle () { Width = longestName });
```

- TableView really needs to leverage LineCanvas. As soon as it does, it will be trivial to always draw the header lines (etc) +1 bigger on each side. If it uses `tableView.LineCanvas` when it does, autojoin with the border will just work!

<img width="628" alt="image" src="https://user-images.githubusercontent.com/585482/234905689-8283f12d-71d0-4326-b23d-edc4cce5660e.png">


That said, i think the header in UI Catalog is overkill and I don't actually think we should leave it in. But i have it enabled so we don't forget about this...